### PR TITLE
Fix messages route statement variable

### DIFF
--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -169,7 +169,7 @@ router.get('/thread/:conversationId', (req, res) => {
             WHERE m.conversationId = ?
             ORDER BY m.timestamp ASC
         `);
-        const messages = stmt.all(conversationId);
+        const messages = messagesStmt.all(conversationId);
         res.json(messages);
     }
     catch (error) {


### PR DESCRIPTION
## Summary
- fix variable in messages thread route to prevent reference error

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node backend/server.js` (start server)
- `curl http://localhost:3000/api/messages/thread/1`

------
https://chatgpt.com/codex/tasks/task_e_684097e654d88327ad15b8af9a17b565