### PR TITLE
Add websocket utilities and integrate with server

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -13,12 +13,14 @@ const postRoutes = require('./src/routes/posts');
 const dealroomRoutes = require('./src/routes/dealrooms');
 const notificationRoutes = require('./src/routes/notifications');
 const messageRoutes = require('./src/routes/messages'); // NEW: Import message routes
-const { setupWebSocketServer } = require('./src/utils/websocketServer');
+const websocket = require('./src/websocket');
 
 const app = express();
 const PORT = 3000;
 const server = http.createServer(app);
-setupWebSocketServer(server);
+websocket.init(server);
+app.locals.sendToUser = websocket.sendToUser;
+app.locals.broadcast = websocket.broadcast;
 
 // Middleware to parse JSON
 app.use(express.json());

--- a/backend/src/websocket.js
+++ b/backend/src/websocket.js
@@ -1,0 +1,50 @@
+const WebSocket = require('ws');
+
+// Map storing userId -> WebSocket connection
+const connections = new Map();
+
+function init(server) {
+  const wss = new WebSocket.Server({ server });
+
+  wss.on('connection', (ws) => {
+    let registeredId = null;
+
+    ws.on('message', (data) => {
+      let msg;
+      try {
+        msg = JSON.parse(data);
+      } catch (err) {
+        return;
+      }
+
+      if (msg && msg.type === 'register' && msg.userId) {
+        registeredId = msg.userId;
+        connections.set(registeredId, ws);
+        return;
+      }
+    });
+
+    ws.on('close', () => {
+      if (registeredId) {
+        connections.delete(registeredId);
+      }
+    });
+  });
+}
+
+function sendToUser(id, type, payload) {
+  const ws = connections.get(id);
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type, payload }));
+  }
+}
+
+function broadcast(ids, type, payload) {
+  ids.forEach((id) => sendToUser(id, type, payload));
+}
+
+module.exports = {
+  init,
+  sendToUser,
+  broadcast,
+};


### PR DESCRIPTION
## Summary
- create `websocket.js` to maintain per-user WebSocket connections and helpers
- initialise the WebSocket server from `backend/server.js`
- expose `sendToUser` and `broadcast` through `app.locals`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415068cbe08327a3cec4ba83ce4630