### PR TITLE
Add WebSocket message delivery

### DIFF
--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const { db } = require('../database/db');
 const { createNotification } = require('../utils/notifications');
+const { sendToUser, broadcast } = require('../utils/websocketHelpers');
 
 const router = express.Router();
 
@@ -76,6 +77,17 @@ router.post('/', async (req, res) => {
             // CORRECTED: Removed 'message_read_id' as it's not in the schema, relies on composite PK
             db.prepare(`INSERT OR IGNORE INTO message_reads (messageId, userId, readAt) VALUES (?, ?, CURRENT_TIMESTAMP)`).run(info.lastInsertRowid, senderId);
 
+            const { timestamp } = db.prepare('SELECT timestamp FROM messages WHERE id = ?').get(info.lastInsertRowid);
+            const payload = { senderId, content, timestamp };
+            if (actualConversationId) payload.conversationId = actualConversationId;
+            if (dealroomId) payload.dealroomId = dealroomId;
+
+            if (actualConversationId && receiverId) {
+                sendToUser(receiverId, { type: 'new_message', data: payload });
+            } else if (dealroomId) {
+                const ids = db.prepare('SELECT userId FROM dealroom_participants WHERE dealroomId = ?').all(dealroomId).map(r => r.userId);
+                broadcast(ids, { type: 'new_message', data: payload });
+            }
 
             res.status(201).json({ message: 'Message sent successfully!', messageId: info.lastInsertRowid });
         } else {

--- a/backend/src/utils/websocketHelpers.js
+++ b/backend/src/utils/websocketHelpers.js
@@ -1,0 +1,21 @@
+const WebSocket = require('ws');
+const { connections } = require('./websocketServer');
+
+function sendToUser(userId, data) {
+  const ws = connections.get(userId);
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(data));
+  }
+}
+
+function broadcast(userIds, data) {
+  const message = JSON.stringify(data);
+  for (const id of userIds) {
+    const ws = connections.get(id);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(message);
+    }
+  }
+}
+
+module.exports = { sendToUser, broadcast };


### PR DESCRIPTION
## Summary
- create websocket helpers for sending payloads to single users or lists
- send new message events to receivers or dealroom participants

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841506da8fc832791dbc25221d8ad94