### PR TITLE
Add WebSocket messaging support

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -995,6 +995,48 @@
         return window.location.href = '/';
       }
 
+      let socket;
+      let socketReady = false;
+
+      function initWebSocket() {
+        socket = new WebSocket(`ws://${window.location.host}`);
+        socket.addEventListener('open', () => {
+          socketReady = true;
+          socket.send(JSON.stringify({ type: 'auth', userId: user.id }));
+        });
+        socket.addEventListener('close', () => { socketReady = false; });
+        socket.addEventListener('message', handleSocketMessage);
+      }
+
+      function handleSocketMessage(event) {
+        let msg;
+        try { msg = JSON.parse(event.data); } catch (err) { return; }
+        if (msg.type === 'new_message') {
+          if (activeConversationId && msg.conversationId === activeConversationId) {
+            fetchAndRenderMessages(activeConversationId);
+            markConversationAsRead(activeConversationId);
+          } else {
+            fetchAndRenderConversations();
+            fetchAndRenderNotifications();
+          }
+        } else if (msg.type === 'new_dealroom_message') {
+          if (activeDealroomData && msg.dealroomId === activeDealroomData.dealroom.id) {
+            openDealroomChat(msg.dealroomId);
+          } else {
+            fetchAndRenderDealrooms();
+            fetchAndRenderNotifications();
+          }
+        }
+      }
+
+      function sendViaSocket(data) {
+        if (socketReady) {
+          socket.send(JSON.stringify(data));
+          return true;
+        }
+        return false;
+      }
+
       // References to main view containers
       const dashboardView = document.getElementById('dashboardView');
       const contactsView = document.getElementById('contactsView');
@@ -1928,6 +1970,18 @@
                   const content = dealroomMessageInput.value.trim();
                   if (content === '') return;
 
+                  const payload = {
+                      type: 'new_dealroom_message',
+                      dealroomId: dealroomData.dealroom.id,
+                      senderId: user.id,
+                      content
+                  };
+
+                  if (sendViaSocket(payload)) {
+                      dealroomMessageInput.value = '';
+                      return;
+                  }
+
                   try {
                       const msgResponse = await fetch('/api/messages', {
                           method: 'POST',
@@ -1948,7 +2002,7 @@
 
                       dealroomMessageInput.value = '';
                       // Re-fetch dealroom details to get updated messages
-                      openDealroomChat(dealroomData.dealroom.id); 
+                      openDealroomChat(dealroomData.dealroom.id);
                   } catch (error) {
                       console.error('Error sending dealroom message:', error);
                       alert(`Error: ${error.message}`);
@@ -2771,6 +2825,19 @@
           const content = messageInput.value.trim();
           if (content === '' || !activeConversationId) return;
 
+          const payload = {
+              type: 'new_message',
+              conversationId: activeConversationId,
+              senderId: user.id,
+              receiverId: currentPartner.id,
+              content
+          };
+
+          if (sendViaSocket(payload)) {
+              messageInput.value = '';
+              return;
+          }
+
           try {
               const response = await fetch('/api/messages', {
                   method: 'POST',
@@ -2780,7 +2847,7 @@
                   body: JSON.stringify({
                       conversationId: activeConversationId,
                       senderId: user.id,
-                      receiverId: currentPartner.id, // Ensure receiverId is passed
+                      receiverId: currentPartner.id,
                       content: content
                   }),
               });
@@ -2820,6 +2887,7 @@
       fetchAndRenderContactsPreview();
       fetchAndRenderPosts();
       fetchAndRenderNotifications(); // Initial fetch of notifications
+      initWebSocket();
     });
 
     function logout() {


### PR DESCRIPTION
## Summary
- establish WebSocket connection on dashboard load
- authenticate the connection with the current user's id
- handle `new_message` and `new_dealroom_message` events to refresh threads or unread counts
- send messages through the socket when available with HTTP fallback

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841506eb7288327a127af300306e735