### PR TITLE
Fix WebSocket outbound message type

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1945,7 +1945,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (content === '' || !activeConversationId) return;
 
         const payload = {
-            type: 'new_message',
+            type: 'send_message',
             conversationId: activeConversationId,
             senderId: user.id,
             receiverId: currentPartner.id,


### PR DESCRIPTION
## Summary
- fix front-end to send `send_message` events when posting chat messages via WebSockets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68419e81cf208327b150fb4b990361c0