### PR TITLE
Add UI to start conversations

### DIFF
--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -26,6 +26,23 @@ async function getOrCreateConversation(user1Id, user2Id) {
     return conversation.id;
 }
 
+// POST /api/messages/start - Get or create a conversation and return its ID
+router.post('/start', async (req, res) => {
+    const { user1Id, user2Id } = req.body;
+
+    if (!user1Id || !user2Id) {
+        return res.status(400).json({ message: 'Both user IDs are required.' });
+    }
+
+    try {
+        const conversationId = await getOrCreateConversation(user1Id, user2Id);
+        res.json({ conversationId });
+    } catch (error) {
+        console.error('Error starting conversation:', error);
+        res.status(500).json({ message: 'Server error starting conversation.' });
+    }
+});
+
 // POST /api/messages - Send a new message
 router.post('/', async (req, res) => {
     const { conversationId, senderId, receiverId, content, dealroomId } = req.body;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -480,6 +480,12 @@
         overflow-y: auto;
     }
 
+    .start-convo-form {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+    }
+
     .conversation-item {
         display: flex;
         align-items: center;
@@ -969,6 +975,13 @@
     <div id="messagesView" class="hidden messages-layout">
         <section class="conversation-list-container">
             <h2 class="text-xl font-bold mb-3 text-white">Inbox</h2>
+            <div id="startConversationArea">
+                <button id="startConversationBtn" class="submitButton mb-3">Start Conversation</button>
+                <div id="newConversationControls" class="start-convo-form hidden">
+                    <select id="contactSelect" class="message-input"></select>
+                    <button id="confirmStartConversationBtn" class="submitButton" disabled>Start</button>
+                </div>
+            </div>
             <div id="conversationList">
                 <p style="text-align: center; color: #888;">No conversations yet.</p>
             </div>


### PR DESCRIPTION
## Summary
- add 'Start Conversation' UI elements
- populate dropdown from contacts and enable/disable start button
- create conversation via new `/api/messages/start` endpoint
- wire new event handlers for messaging view

## Testing
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_6841af8b2f008327abfc7383631a5834