### PR TITLE
Add conversation start header

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -472,6 +472,13 @@
         gap: 1rem;
     }
 
+    .messages-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+    }
+
     .conversation-list-container {
         flex: 1;
         background-color: #1e1e2f;
@@ -974,13 +981,13 @@
 
     <div id="messagesView" class="hidden messages-layout">
         <section class="conversation-list-container">
-            <h2 class="text-xl font-bold mb-3 text-white">Inbox</h2>
-            <div id="startConversationArea">
-                <button id="startConversationBtn" class="submitButton mb-3">Start Conversation</button>
-                <div id="newConversationControls" class="start-convo-form hidden">
-                    <select id="contactSelect" class="message-input"></select>
-                    <button id="confirmStartConversationBtn" class="submitButton" disabled>Start</button>
-                </div>
+            <div class="messages-header">
+                <h2 class="text-xl font-bold text-white">Inbox</h2>
+                <button id="startConversationBtn" class="submitButton">Start Conversation</button>
+            </div>
+            <div id="newConversationControls" class="start-convo-form hidden">
+                <select id="contactSelect" class="message-input"></select>
+                <button id="confirmStartConversationBtn" class="submitButton" disabled>Start</button>
             </div>
             <div id="conversationList">
                 <p style="text-align: center; color: #888;">No conversations yet.</p>


### PR DESCRIPTION
## Summary
- move start conversation controls to a header in the message tab
- style new header area

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc098d24832788ba4d3d1c433465